### PR TITLE
Replace platform-dependent build-demos scripts with npm script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD . /app
 
 WORKDIR /app
 
-RUN npm install && sh build-demos.sh
+RUN npm install && npm run build-demos
 
 EXPOSE 7829
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,7 @@ This error is thrown on Windows systems when the path length limit is hit. Move 
     ```
     $ npm install
 
-    # Windows
-    $ build-demos.bat
-
-    # macOS / Linux
-    $ sh build-demos.sh
+    $ npm run build-demos
     ```
 
 1. Then, start a web server:
@@ -238,17 +234,8 @@ After changing anything in the simulator HAL, you need to recompile the libmbed 
 ## Updating demo's
 
 In the `out` folder a number of pre-built demos are listed. To upgrade them:
-
-**macOS and Linux**
-
 ```
-$ sh build-demos.sh
-```
-
-**Windows**
-
-```
-$ build-demos.bat
+$ npm run build-demos
 ```
 
 ## Attribution

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Last, install the simulator. Easiest is through npm:
 1. Install the simulator through git:
 
     ```
-    $ git clone https://github.com/janjongboom/mbed-simulator.git
+    $ git clone https://github.com/ARMmbed/mbed-simulator.git
     $ cd mbed-simulator
     $ npm install
     $ npm install . -g

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ After changing anything in the simulator HAL, you need to recompile the libmbed 
 
 1. Rebuild your application. libmbed will automatically be generated.
 
-## Updating demo's
+## Updating demos
 
 In the `out` folder a number of pre-built demos are listed. To upgrade them:
 ```

--- a/build-demos.bat
+++ b/build-demos.bat
@@ -1,1 +1,0 @@
-for /D %%s in (demos/*) do @echo Building demos/%%s... && node cli.js -i demos/%%s -o out/ --compiler-opts "-Os"

--- a/build-demos.js
+++ b/build-demos.js
@@ -4,15 +4,15 @@ const fs = require('fs');
 
 const demo_output_directory = 'out';
 
-function buildDirectory(demos_dir, directory) {
-    console.log(`Building ${directory}...`);
+function buildDemo(root_demos_directory, demo_directory) {
+    console.log(`Building ${demo_directory}...`);
 
     const buildResult = child_process.spawnSync(
         'node',
         [
             'cli.js',
             '-i',
-            `${demos_dir}/${directory}`,
+            `${root_demos_directory}/${demo_directory}`,
             '-o',
             demo_output_directory,
             '--compiler-opts',
@@ -37,5 +37,5 @@ if (!fs.existsSync(demo_output_directory)) {
 }
 
 fs.readdir(program.inputDir, (err, directories) => directories.map(
-    directory => buildDirectory(program.inputDir, directory)
+    directory => buildDemo(program.inputDir, directory)
 ));

--- a/build-demos.js
+++ b/build-demos.js
@@ -1,0 +1,36 @@
+const child_process = require('child_process');
+const fs = require('fs');
+
+const demos_directory = 'demos';
+const demo_output_directory = 'out';
+
+function buildDirectory(directory) {
+    console.log(`Building ${directory}...`);
+
+    const buildResult = child_process.spawnSync(
+        'node',
+        [
+            'cli.js',
+            '-i',
+            `${demos_directory}/${directory}`,
+            '-o',
+            demo_output_directory,
+            '--compiler-opts',
+            '-Os'
+        ]
+    );
+
+    if (buildResult.status === 0) {
+        console.log(buildResult.stdout.toString());
+    } else {
+        console.log(buildResult.stderr.toString());
+    }
+}
+
+if (!fs.existsSync(demo_output_directory)) {
+     fs.mkdirSync(demo_output_directory);
+}
+
+fs.readdir(demos_directory, (err, directories) => directories.map(
+    directory => buildDirectory(directory)
+));

--- a/build-demos.js
+++ b/build-demos.js
@@ -1,10 +1,10 @@
 const child_process = require('child_process');
+const program = require('commander');
 const fs = require('fs');
 
-const demos_directory = 'demos';
 const demo_output_directory = 'out';
 
-function buildDirectory(directory) {
+function buildDirectory(demos_dir, directory) {
     console.log(`Building ${directory}...`);
 
     const buildResult = child_process.spawnSync(
@@ -12,7 +12,7 @@ function buildDirectory(directory) {
         [
             'cli.js',
             '-i',
-            `${demos_directory}/${directory}`,
+            `${demos_dir}/${directory}`,
             '-o',
             demo_output_directory,
             '--compiler-opts',
@@ -27,10 +27,15 @@ function buildDirectory(directory) {
     }
 }
 
+program.option(
+    '-i --input-dir <dir>', 'Input directory for the demos', 'demos'
+);
+program.parse(process.argv);
+
 if (!fs.existsSync(demo_output_directory)) {
      fs.mkdirSync(demo_output_directory);
 }
 
-fs.readdir(demos_directory, (err, directories) => directories.map(
-    directory => buildDirectory(directory)
+fs.readdir(program.inputDir, (err, directories) => directories.map(
+    directory => buildDirectory(program.inputDir, directory)
 ));

--- a/build-demos.sh
+++ b/build-demos.sh
@@ -1,5 +1,0 @@
-for dir in demos/*/
-do
-    echo "Building ${dir}..."
-    node cli.js -i ${dir} -o out/ --compiler-opts "-Os"
-done

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,9 +131,9 @@
       "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
     },
     "commander": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
-      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
     },
     "component-bind": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Mbed OS 5 simulator",
   "preferGlobal": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build-demos": "node build-demos.js"
   },
   "bin": {
     "mbed-simulator": "./cli.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "body-parser": "^1.18.2",
     "command-exists": "^1.2.2",
-    "commander": "^4.0.1",
+    "commander": "^4.1.0",
     "compression": "^1.7.3",
     "es6-promisify": "^6.0.0",
     "express": "^4.16.2",

--- a/viewer/simulator.html
+++ b/viewer/simulator.html
@@ -18,8 +18,8 @@
     Arm Mbed OS simulator
 
     <span id="links">
-      <a target="_blank" href="https://github.com/janjongboom/mbed-simulator#cli">Download offline version</a> |
-      <a target="_blank" href="https://github.com/janjongboom/mbed-simulator">GitHub project</a>
+      <a target="_blank" href="https://github.com/ARMMbed/mbed-simulator#cli">Download offline version</a> |
+      <a target="_blank" href="https://github.com/ARMMbed/mbed-simulator">GitHub project</a>
     </span>
   </section>
 

--- a/viewer/simulator.html
+++ b/viewer/simulator.html
@@ -27,7 +27,7 @@
     <section id="editor-container">
       <div id="editor-topbar">
         <select id="select-project">
-          <option disabled>-- Basic demo's --</option>
+          <option disabled>-- Basic demos --</option>
           <option selected name="blinky">Blinky</option>
           <option name="interrupts">Interrupts</option>
           <option name="events">Events</option>


### PR DESCRIPTION
This is the first stage in the work to support building extra demos to add to the simulator. I re-wrote the build-demos script in JS and added it as an npm script, and removed the old sh and bat scripts.

I also added the option of providing an argument to the script, which is an input directory where the demos are located.

I also fixed some typos, and amended some links as part of this PR.

@BenMartin1494 has done some more work on top of this which changes the HTML template to dynamically add the demos to the list, rather than them being hard-coded, so that will complete this piece of work.

@thegecko can we give @BenMartin1494 and @HugoSilvaSantos permission to push to this repo? They did some work on this but couldn't push their branches in for pull request.